### PR TITLE
week3 풀이 (findawayer)

### DIFF
--- a/src/week3.balacend-brackets/findawayer.js
+++ b/src/week3.balacend-brackets/findawayer.js
@@ -1,3 +1,5 @@
+// https://programmers.co.kr/learn/courses/30/lessons/12909
+
 // 정확성  테스트
 // 테스트 1 〉	통과 (0.07ms, 29.9MB)
 // 테스트 2 〉	통과 (0.09ms, 30MB)

--- a/src/week3.balacend-brackets/findawayer.js
+++ b/src/week3.balacend-brackets/findawayer.js
@@ -1,0 +1,94 @@
+// 정확성  테스트
+// 테스트 1 〉	통과 (0.07ms, 29.9MB)
+// 테스트 2 〉	통과 (0.09ms, 30MB)
+// 테스트 3 〉	통과 (0.07ms, 30.2MB)
+// 테스트 4 〉	통과 (0.08ms, 30.2MB)
+// 테스트 5 〉	통과 (0.08ms, 30MB)
+// 테스트 6 〉	통과 (0.07ms, 30.1MB)
+// 테스트 7 〉	통과 (0.09ms, 30.1MB)
+// 테스트 8 〉	통과 (0.09ms, 30MB)
+// 테스트 9 〉	통과 (0.09ms, 30.1MB)
+// 테스트 10 〉	통과 (0.09ms, 29.9MB)
+// 테스트 11 〉	통과 (0.08ms, 29.7MB)
+// 테스트 12 〉	통과 (0.12ms, 30.1MB)
+// 테스트 13 〉	통과 (0.07ms, 30MB)
+// 테스트 14 〉	통과 (0.11ms, 30.1MB)
+// 테스트 15 〉	통과 (0.11ms, 29.9MB)
+// 테스트 16 〉	통과 (0.12ms, 29.8MB)
+// 테스트 17 〉	통과 (0.07ms, 30MB)
+// 테스트 18 〉	통과 (0.11ms, 30.1MB)
+
+// 효율성  테스트
+// 테스트 1 〉	통과 (8.22ms, 35.4MB)
+// 테스트 2 〉	통과 (12.88ms, 35.5MB)
+
+function areBalanced(s) {
+  const BRACKET_CLOSE = ')';
+
+  if (s.length % 2 || s[0] === BRACKET_CLOSE) return false;
+
+  const stack = [];
+
+  for (const token of s) {
+    if (token === BRACKET_CLOSE && stack[stack.length - 1] !== token)
+      stack.pop();
+    else stack.push(token);
+  }
+
+  return !stack.length;
+}
+
+describe('balacend-brackets', () => {
+  test.each`
+    input       | output
+    ${'()()'}   | ${true}
+    ${'(())()'} | ${true}
+    ${')()('}   | ${false}
+    ${'(()('}   | ${false}
+  `('returns $output from $input', ({ input, output }) => {
+    expect(areBalanced(input)).toBe(output);
+  });
+});
+
+// 정확성  테스트
+// 테스트 1 〉	통과 (0.12ms, 30.1MB)
+// 테스트 2 〉	통과 (0.11ms, 30.1MB)
+// 테스트 3 〉	통과 (0.11ms, 30.1MB)
+// 테스트 4 〉	통과 (0.11ms, 30.1MB)
+// 테스트 5 〉	통과 (0.11ms, 30.2MB)
+// 테스트 6 〉	통과 (0.10ms, 30MB)
+// 테스트 7 〉	통과 (0.08ms, 30.2MB)
+// 테스트 8 〉	통과 (0.08ms, 30MB)
+// 테스트 9 〉	통과 (0.09ms, 30MB)
+// 테스트 10 〉	통과 (0.09ms, 30.1MB)
+// 테스트 11 〉	통과 (0.12ms, 29.9MB)
+// 테스트 12 〉	통과 (0.11ms, 30.2MB)
+// 테스트 13 〉	통과 (0.11ms, 30.2MB)
+// 테스트 14 〉	통과 (0.10ms, 30MB)
+// 테스트 15 〉	통과 (0.11ms, 30.1MB)
+// 테스트 16 〉	통과 (0.12ms, 30.2MB)
+// 테스트 17 〉	통과 (0.24ms, 30MB)
+// 테스트 18 〉	통과 (0.13ms, 29.9MB)
+// 효율성  테스트
+// 테스트 1 〉	실패 (7.18ms, 33.4MB)
+// 테스트 2 〉	통과 (7.14ms, 33.3MB)
+function areBalancedEval(s) {
+  try {
+    eval(s.replace(/\(\)/g, '(0)').replace(/\)\(/g, '),('));
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+describe('balacend-brackets-eval', () => {
+  test.each`
+    input       | output
+    ${'()()'}   | ${true}
+    ${'(())()'} | ${true}
+    ${')()('}   | ${false}
+    ${'(()('}   | ${false}
+  `('returns $output from $input', ({ input, output }) => {
+    expect(areBalancedEval(input)).toBe(output);
+  });
+});

--- a/src/week3.greatest-common-divisor/findawayer.js
+++ b/src/week3.greatest-common-divisor/findawayer.js
@@ -1,0 +1,100 @@
+// https://www.hackerearth.com/practice/data-structures/advanced-data-structures/segment-trees/practice-problems/algorithm/cool-gcd-789acd8e/
+
+// HackerEarth를 위한 I/O 코드
+
+// process.stdin.resume();
+// process.stdin.setEncoding('utf-8');
+
+// var stdin_input = '';
+
+// process.stdin.on('data', function (input) {
+//   stdin_input += input;
+// });
+
+// process.stdin.on('end', function () {
+//   main(stdin_input);
+// });
+
+// function main(input) {
+//   const output = solve(input);
+//   process.stdout.write(output);
+// }
+
+function solve(input) {
+  const actions = {
+    1: replaceWith,
+    2: replaceWithGCD,
+    3: printMaxValue,
+    4: printSum,
+  };
+  const [, elements, ...queries] = input.split('\n');
+  const array = parseQuery(elements);
+  const output = [];
+
+  for (const query of queries) {
+    const [type, ...args] = parseQuery(query);
+    const action = actions[type];
+    const result = action(array, ...args);
+    if (result) output.push(result);
+  }
+
+  return output.join('\n');
+}
+
+function parseQuery(query) {
+  return query.split(' ').map(Number);
+}
+
+function replaceWith(array, left, right, value) {
+  for (let i = left - 1; i < right; i += 1) array[i] = value;
+}
+
+function replaceWithGCD(array, left, right, value) {
+  for (let i = left - 1; i < right; i += 1) array[i] = gcd(array[i], value);
+}
+
+function printMaxValue(array, left, right) {
+  let max = 0; // n >= 0
+  for (let i = left - 1; i < right; i += 1) if (array[i] > max) max = array[i];
+  return max;
+}
+
+function printSum(array, left, right) {
+  let sum = 0;
+  for (let i = left - 1; i < right; i += 1) sum += array[i];
+  return sum;
+}
+
+function gcd(a, b) {
+  if (!a) return b;
+  if (!b) return a;
+  if (a === b) return a;
+
+  while (b) {
+    if (a > b) a -= b;
+    else b -= a;
+  }
+
+  return a;
+}
+
+describe('greatest-common-divisor', () => {
+  const input = dedent(`
+    4 6
+    10 12 6 8
+    3 1 4
+    4 1 4
+    2 2 4 4
+    3 2 4
+    1 1 4 2
+    4 1 4
+  `);
+  const output = [12, 36, 4, 8];
+  it('returns', () => {
+    expect(solve(input)).toEqual(output);
+  });
+});
+
+function dedent(string) {
+  return string.trim().replace(/^\s+/gm, '');
+}

--- a/src/week3.id-suggestions/findawayer.js
+++ b/src/week3.id-suggestions/findawayer.js
@@ -1,3 +1,4 @@
+// https://programmers.co.kr/learn/courses/30/lessons/72410
 // 테스트 1 〉	통과 (0.20ms, 30.3MB)
 // 테스트 2 〉	통과 (0.20ms, 30.1MB)
 // 테스트 3 〉	통과 (0.20ms, 29.9MB)

--- a/src/week3.id-suggestions/findawayer.js
+++ b/src/week3.id-suggestions/findawayer.js
@@ -1,0 +1,52 @@
+// 테스트 1 〉	통과 (0.20ms, 30.3MB)
+// 테스트 2 〉	통과 (0.20ms, 30.1MB)
+// 테스트 3 〉	통과 (0.20ms, 29.9MB)
+// 테스트 4 〉	통과 (0.21ms, 30.1MB)
+// 테스트 5 〉	통과 (0.19ms, 29.9MB)
+// 테스트 6 〉	통과 (0.20ms, 30.1MB)
+// 테스트 7 〉	통과 (0.20ms, 29.9MB)
+// 테스트 8 〉	통과 (0.19ms, 30.2MB)
+// 테스트 9 〉	통과 (0.20ms, 29.9MB)
+// 테스트 10 〉	통과 (0.41ms, 29.9MB)
+// 테스트 11 〉	통과 (0.20ms, 30.1MB)
+// 테스트 12 〉	통과 (0.24ms, 29.9MB)
+// 테스트 13 〉	통과 (0.22ms, 30MB)
+// 테스트 14 〉	통과 (0.21ms, 30.1MB)
+// 테스트 15 〉	통과 (0.20ms, 30MB)
+// 테스트 16 〉	통과 (0.29ms, 30MB)
+// 테스트 17 〉	통과 (0.25ms, 30.1MB)
+// 테스트 18 〉	통과 (0.27ms, 30MB)
+// 테스트 19 〉	통과 (0.30ms, 30MB)
+// 테스트 20 〉	통과 (0.35ms, 29.9MB)
+// 테스트 21 〉	통과 (0.32ms, 30.2MB)
+// 테스트 22 〉	통과 (0.31ms, 30.1MB)
+// 테스트 23 〉	통과 (0.21ms, 29.9MB)
+// 테스트 24 〉	통과 (0.24ms, 30.1MB)
+// 테스트 25 〉	통과 (0.22ms, 30MB)
+// 테스트 26 〉	통과 (0.21ms, 29.8MB)
+function solution(new_id) {
+  const $id = new_id
+    .toLowerCase() // 1
+    .replace(/[^\w-_.]/g, '') // 2
+    .replace(/(?:^\.+|\.+(?=\.)|\.+$)/g, ''); // 3 + 4
+
+  const { length } = $id;
+  if (!length) return 'aaa'; // 5
+  if (length > 15) return $id.slice(0, 15).replace(/\.$/, ''); // 6
+  if (length < 3) return $id.padEnd(3, $id[length - 1]); // 7
+
+  return $id;
+}
+
+describe('id-suggestions', () => {
+  test.each`
+    input                            | output
+    ${'...!@BaT#*..y.abcdefghijklm'} | ${'bat.y.abcdefghi'}
+    ${'z-+.^.'}                      | ${'z--'}
+    ${'=.='}                         | ${'aaa'}
+    ${'123_.def'}                    | ${'123_.def'}
+    ${'abcdefghijklmn.p'}            | ${'abcdefghijklmn'}
+  `('returns $output from $input', ({ input, output }) => {
+    expect(solution(input)).toBe(output);
+  });
+});

--- a/src/week3.reduce-array-to-the-half/findawayer.js
+++ b/src/week3.reduce-array-to-the-half/findawayer.js
@@ -1,0 +1,41 @@
+// https://leetcode.com/problems/reduce-array-size-to-the-half/
+// Runtime: 148 ms, faster than 60.64% of JavaScript online submissions for Reduce Array Size to The Half.
+// Memory Usage: 53.9 MB, less than 50.32% of JavaScript online submissions for Reduce Array Size to The Half.
+
+function minSetSize(arr) {
+  const { length } = arr;
+
+  if (length < 1) return length;
+
+  // 배열 안에서 각 원소가 중복된 횟수를 맵의 형태로 저장.
+  const sizes = {};
+  for (const key of arr) sizes[key] = sizes[key] + 1 || 1;
+  // 중복이 많은 순서대로 원소를 정렬
+  const sortedKeys = Object.keys(sizes).sort((a, z) => sizes[z] - sizes[a]);
+
+  // 배열 안에 남은 원소가 절반 이하가 될 때까지, 중복이 많은 원소부터 소거
+  const halfLength = length / 2;
+  let sum = 0;
+  let i = 0;
+
+  while (sum < halfLength) {
+    sum += sizes[sortedKeys[i]];
+    i += 1;
+  }
+
+  // 제거한 원소의 가짓수가 정답
+  return i;
+}
+
+describe('reduce-array-to-the-half', () => {
+  test.each`
+    input                              | output
+    ${[3, 3, 3, 3, 5, 5, 5, 2, 2, 7]}  | ${2}
+    ${[7, 7, 7, 7, 7, 7]}              | ${1}
+    ${[1, 9]}                          | ${1}
+    ${[1000, 1000, 3, 7]}              | ${1}
+    ${[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]} | ${5}
+  `('returns $output from $input', ({ input, output }) => {
+    expect(minSetSize(input)).toBe(output);
+  });
+});

--- a/src/week3.rotting-oranges/findawayer.js
+++ b/src/week3.rotting-oranges/findawayer.js
@@ -1,0 +1,67 @@
+// v1: https://leetcode.com/submissions/detail/451888091/
+// Runtime: 116 ms, faster than 21.98% of JavaScript online submissions for Rotting Oranges.
+// Memory Usage: 45.4 MB, less than 7.39% of JavaScript online submissions for Rotting Oranges.
+
+// v2: https://leetcode.com/submissions/detail/451896272/
+// Runtime: 124 ms.
+// Memory Usage: 44.8 MB.
+
+// v3: https://leetcode.com/submissions/detail/451898826/
+// Runtime: 96 ms, faster than 57.59% of JavaScript online submissions for Rotting Oranges.
+// Memory Usage: 41.3 MB, less than 34.63% of JavaScript online submissions for Rotting Oranges.
+
+// BFS 검색
+function orangesRotting(grid) {
+  // 맨 처음 썩어 있는 오렌지
+  const queue = [];
+  // 신선한 오렌지
+  let fresh = 0;
+  // 전염에 걸린 시간
+  let time = 0;
+  // BFS 검색 깊이
+  let depth = 0;
+  // 인접한 셀을 구하는 데 필요한 오프셋 값
+  const offsets = [
+    { dx: -1, dy: 0 },
+    { dx: 0, dy: -1 },
+    { dx: 1, dy: 0 },
+    { dx: 0, dy: 1 },
+  ];
+
+  grid.forEach((row, y) => {
+    row.forEach((cell, x) => {
+      if (cell === 2) queue.push({ x, y, time });
+      else if (cell === 1) fresh += 1;
+    });
+  });
+
+  while (queue.length) {
+    const { x, y, time } = queue.shift();
+
+    for (const { dx, dy } of offsets) {
+      const tx = x + dx;
+      const ty = y + dy;
+      // 유효하지 않은 셀, 빈 셀, 이미 썩은 오렌지 셀은 스킵
+      if (!grid[ty] || grid[ty][tx] !== 1) continue;
+
+      queue.push({ x: tx, y: ty, time: time + 1 });
+      grid[ty][tx] = 2;
+      fresh -= 1;
+    }
+
+    depth = time;
+  }
+
+  return fresh ? -1 : depth;
+}
+
+describe('rotting-oranges', () => {
+  test.each`
+    grid                                 | minutes
+    ${[[2, 1, 1], [1, 1, 0], [0, 1, 1]]} | ${4}
+    ${[[2, 1, 1], [0, 1, 1], [1, 0, 1]]} | ${-1}
+    ${[[0, 2]]}                          | ${0}
+  `('returns $minutes from $grid', ({ grid, minutes }) => {
+    expect(orangesRotting(grid)).toBe(minutes);
+  });
+});

--- a/src/week3.rotting-oranges/findawayer.js
+++ b/src/week3.rotting-oranges/findawayer.js
@@ -10,10 +10,15 @@
 // Runtime: 96 ms, faster than 57.59% of JavaScript online submissions for Rotting Oranges.
 // Memory Usage: 41.3 MB, less than 34.63% of JavaScript online submissions for Rotting Oranges.
 
-// BFS 검색
+// v4: https://leetcode.com/submissions/detail/452313850/
+// Runtime: 88 ms, faster than 88.61% of JavaScript online submissions for Rotting Oranges.
+// Memory Usage: 41 MB, less than 57.53% of JavaScript online submissions for Rotting Oranges.
+
 function orangesRotting(grid) {
-  // 맨 처음 썩어 있는 오렌지
+  // BFS 검색 큐
   const queue = [];
+  // 위 큐의 현재 노드를 가리키는 포인터
+  let tail = 0;
   // 신선한 오렌지
   let fresh = 0;
   // 전염에 걸린 시간
@@ -35,8 +40,8 @@ function orangesRotting(grid) {
     });
   });
 
-  while (queue.length) {
-    const { x, y, time } = queue.shift();
+  while (tail < queue.length) {
+    const { x, y, time } = queue[tail];
 
     for (const { dx, dy } of offsets) {
       const tx = x + dx;
@@ -50,6 +55,7 @@ function orangesRotting(grid) {
     }
 
     depth = time;
+    tail += 1;
   }
 
   return fresh ? -1 : depth;

--- a/src/week3.rotting-oranges/findawayer.js
+++ b/src/week3.rotting-oranges/findawayer.js
@@ -1,3 +1,5 @@
+// https://leetcode.com/problems/rotting-oranges/
+
 // v1: https://leetcode.com/submissions/detail/451888091/
 // Runtime: 116 ms, faster than 21.98% of JavaScript online submissions for Rotting Oranges.
 // Memory Usage: 45.4 MB, less than 7.39% of JavaScript online submissions for Rotting Oranges.

--- a/src/week3.search-ranking/findawayer.js
+++ b/src/week3.search-ranking/findawayer.js
@@ -1,0 +1,100 @@
+// 정확성  테스트
+// 테스트 1 〉	통과 (0.90ms, 29.8MB)
+// 테스트 2 〉	통과 (0.64ms, 30.1MB)
+// 테스트 3 〉	통과 (1.06ms, 30.1MB)
+// 테스트 4 〉	통과 (7.12ms, 34.1MB)
+// 테스트 5 〉	통과 (15.17ms, 35.6MB)
+// 테스트 6 〉	통과 (21.29ms, 34.5MB)
+// 테스트 7 〉	통과 (17.73ms, 35.7MB)
+// 테스트 8 〉	통과 (21.34ms, 35.4MB)
+// 테스트 9 〉	통과 (34.46ms, 36.8MB)
+// 테스트 10 〉	통과 (41.08ms, 36.7MB)
+// 테스트 11 〉	통과 (14.40ms, 33.8MB)
+// 테스트 12 〉	통과 (17.02ms, 33.5MB)
+// 테스트 13 〉	통과 (16.26ms, 34MB)
+// 테스트 14 〉	통과 (32.19ms, 35.1MB)
+// 테스트 15 〉	통과 (28.18ms, 34.7MB)
+// 테스트 16 〉	통과 (14.58ms, 35.1MB)
+// 테스트 17 〉	통과 (16.97ms, 34MB)
+// 테스트 18 〉	통과 (28.41ms, 34.8MB)
+// 효율성  테스트
+// 테스트 1 〉	실패 (시간 초과)
+// 테스트 2 〉	실패 (시간 초과)
+// 테스트 3 〉	실패 (시간 초과)
+// 테스트 4 〉	실패 (시간 초과)
+function solution(entries, queries) {
+  const trie = entries.reduce((node, entry) => {
+    let current = node;
+    entry.split(' ').forEach(value => {
+      if (!(value in current)) {
+        current[value] = createNode();
+      } else {
+        current[value].__size__ += 1;
+      }
+      current = current[value];
+    });
+    return node;
+  }, {});
+
+  return queries.map(query => match(trie, parseQuery(query)));
+}
+
+function createNode() {
+  const object = Object.create(null);
+  Object.defineProperty(object, '__size__', {
+    value: 1,
+    writable: true,
+  });
+  return object;
+}
+
+function parseQuery(query) {
+  return query.match(/(-|\b(?!and)\w+\b)/g);
+}
+
+function match(node, queryList, queryIndex = 0, found = 0) {
+  if (!node) return 0;
+  if (!(queryIndex in queryList)) return node.__size__;
+
+  const queryItem = queryList[queryIndex];
+
+  if (queryItem === '-') {
+    for (const key in node) {
+      found += match(node[key], queryList, queryIndex + 1);
+    }
+  } else if (!isNaN(queryItem)) {
+    for (const key in node) {
+      if (Number(key) >= Number(queryItem)) {
+        found += match(node[key], queryList, queryIndex + 1);
+      }
+    }
+  } else if (queryItem in node) {
+    found += match(node[queryItem], queryList, queryIndex + 1);
+  }
+
+  return found;
+}
+
+describe('search-ranking', () => {
+  const input = [
+    'java backend junior pizza 150',
+    'python frontend senior chicken 210',
+    'python frontend senior chicken 150',
+    'cpp backend senior pizza 260',
+    'java backend junior chicken 80',
+    'python backend senior chicken 50',
+  ];
+  const query = [
+    'java and backend and junior and pizza 100',
+    'python and frontend and senior and chicken 200',
+    'cpp and - and senior and pizza 250',
+    '- and backend and senior and - 150',
+    '- and - and - and chicken 100',
+    '- and - and - and - 150',
+  ];
+  const output = [1, 1, 1, 1, 2, 4];
+
+  it('should return', () => {
+    expect(solution(input, query)).toEqual(output);
+  });
+});

--- a/src/week3.search-ranking/findawayer.js
+++ b/src/week3.search-ranking/findawayer.js
@@ -1,3 +1,5 @@
+// https://programmers.co.kr/learn/courses/30/lessons/72412
+
 // 정확성  테스트
 // 테스트 1 〉	통과 (0.90ms, 29.8MB)
 // 테스트 2 〉	통과 (0.64ms, 30.1MB)


### PR DESCRIPTION
`card-matching` 이외의 문제에 대한 풀이입니다. `card-matching`은 필요한 키 입력 횟수를 구하는 데는 성공했는데 시간 안에 맞는 답을 구하는 데 실패했네요. 조금 더 풀어봐야 할 것 같습니다.

## balanced brackets

대/중/소괄호를 섞은 문제와 같은 방식으로 스택을 이용해 풀었습니다. 제출하고 나서 다른 사람들의 답안을 보니 괄호 종류가 1개라는 점을 감안해 스택 대신 괄호 카운트만 사용해도 될 것 같더라구요.

심심해서 `eval`을 사용한 버전도 하나 만들어 봤습니다. 그런데 효율성 테스트에서 하나 실패가 뜨는데 어느 부분이 잘못됐을지 짐작이 안 됩니다. 보고 뭔가 떠오르시는 분은 힌트 부탁드려요.

## greatest common divisor

답은 맞게 제출했는데 문제의 의도는 segment tree를 사용해 보라고 낸 문제라 역시 효율성에서 타임아웃이 나와서 망했네요 😂 segment tree를 이용한 답안으로 바꿔서 풀어봐야겠어요.

## id suggestions

상대적으로 간단한 문제였죠. 막상 제출하고 보니 제가 `.repeat()`를 사용해 푼 부분을 `.padEnd()`로 푼 답안이 보여서 이 부분을 업데이트해 봤습니다. 평소에 잘 쓰질 않다 보니 메소드의 존재를 잊고 있었네요.

## rotting oranges

BFS 구현에 익숙해지기 위해서 의도적으로 선택한 문제기 때문에, 계획대로 BFS를 사용해 풀었습니다. 최적화를 몇 번 거치면서 몇 가지 공간/시간 복잡도를 줄이는 방법을 배웠습니다. 궁금하신 분은 맨 위 주석에 남겨진 히스토리를 읽어주세요.

## search ranking

이것도 실패한 구현... 🙄 효율성 테스트에서 타임아웃이 나오는 걸 보니, 근본부터 접근 방식을 개선할 필요가 있어 보입니다. 저는 Trie를 이용해서 쿼리에 대응하는 노드의 갯수를 찾아내도록 했는데 이걸론 부족한 거 같네요. 아직 어떻게 하면 좋을지 고민이 됩니다.